### PR TITLE
Expand error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ We do not recommend installing development utilities on a live site.
 
 Set `WP_DEBUG` to `true` in your WordPress installation's `wp-config.php` file to enable a debug display in the "More" dropdown under the StackPath logo. This debug information includes some system information, a list of WordPres plugins installed, and the StackPath plugin's configuration.
 
+Set `WP_DEBUG` and `WP_DEBUG_DISPLAY` to `true` to display low level StackPath API call information in non-AJAX error messages.
+
+Set `WP_DEBUG` to true and set `WP_DEBUG_LOG` to a valid value to report low level StackPath API call information to WordPress's error log.
+
 ## Contributing
 
 We happily accept pull requests! Check out our [contributing guide](https://github.com/stackpath/stackpath-wordpress/blob/master/.github/contributing.md) if you'd like to help out.

--- a/css/style.css
+++ b/css/style.css
@@ -264,3 +264,18 @@ Metrics graphs
   margin-left: auto;
   margin-right: auto;
 }
+
+.stackpath-message-debug-information {
+  padding: 0.5em;
+  margin-bottom: 12px;
+  border: 1px solid #e5e5e5;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+  max-height: 100px;
+  overflow: scroll;
+  background: #fff;
+}
+
+.stackpath-message-debug-information-value {
+  margin-top: 0;
+  font-family: Consolas,Monaco,monospace;
+}

--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -26,7 +26,7 @@ class Client
     const DEFAULT_REQUEST_OPTIONS = [
         'timeout' => 60,
         'httpversion' => '1.1',
-        'user-agent' => 'StackPath WordPress Plugin/[VERSION] (+https://github.com/stackpath/stackpath-wordpress)',
+        'user-agent' => 'StackPath WordPress Plugin/%s (+https://github.com/stackpath/stackpath-wordpress)',
         'headers' => [
             'Content-Type' => 'application/json',
             'Accept' => 'application/json',
@@ -137,7 +137,7 @@ class Client
         // Prepare the request
         $requestOptions = array_merge_recursive(self::DEFAULT_REQUEST_OPTIONS, $options);
         $requestOptions['method'] = $method;
-        $requestOptions['user-agent'] = str_replace('[VERSION]', $this->pluginVersion, $requestOptions['user-agent']);
+        $requestOptions['user-agent'] = sprintf($requestOptions['user-agent'], $this->pluginVersion);
 
         // See if this call needs a bearer token
         $addAuthHeader = true;

--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -180,6 +180,7 @@ class Client
         // Recast the response as a StackPath API response
         $response = Response::fromWordPressResponse($response['http_response']->get_response_object());
         $response->decodeBody();
+        $response->findRequestId();
 
         // If the call was a failure then throw the appropriate exception
         if (!$response->success) {

--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -183,7 +183,7 @@ class Client
 
         // If the call was a failure then throw the appropriate exception
         if (!$response->success) {
-            throw RequestException::create($url, $requestOptions, $response);
+            throw RequestException::create($this->pluginVersion, $url, $requestOptions, $response);
         }
 
         // Finally, return the successful response

--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -26,7 +26,7 @@ class Client
     const DEFAULT_REQUEST_OPTIONS = [
         'timeout' => 60,
         'httpversion' => '1.1',
-        'user-agent' => 'StackPath WordPress plugin API client: ' . __CLASS__,
+        'user-agent' => 'StackPath WordPress Plugin/[VERSION] (+https://github.com/stackpath/stackpath-wordpress)',
         'headers' => [
             'Content-Type' => 'application/json',
             'Accept' => 'application/json',
@@ -62,6 +62,13 @@ class Client
     protected $wordPress;
 
     /**
+     * The WordPress plugin's version for use in User-Agent strings
+     *
+     * @var string
+     */
+    protected $pluginVersion;
+
+    /**
      * Build a StackPath API client
      *
      * @param Settings $settings
@@ -71,6 +78,16 @@ class Client
     {
         $this->settings = $settings;
         $this->wordPress = $wordPress;
+    }
+
+    /**
+     * Set the plugin's version for use in User-Agent strings
+     *
+     * @param string $version
+     */
+    public function setPluginVersion($version)
+    {
+        $this->pluginVersion = $version;
     }
 
     /**
@@ -85,6 +102,7 @@ class Client
     public function authenticate()
     {
         $client = new self($this->settings, $this->wordPress);
+        $client->setPluginVersion($this->pluginVersion);
 
         $result = $client->post('/identity/v1/oauth2/token', [
             'body' => json_encode([
@@ -119,6 +137,7 @@ class Client
         // Prepare the request
         $requestOptions = array_merge_recursive(self::DEFAULT_REQUEST_OPTIONS, $options);
         $requestOptions['method'] = $method;
+        $requestOptions['user-agent'] = str_replace('[VERSION]', $this->pluginVersion, $requestOptions['user-agent']);
 
         // See if this call needs a bearer token
         $addAuthHeader = true;

--- a/src/Exception/API/RequestException.php
+++ b/src/Exception/API/RequestException.php
@@ -56,7 +56,7 @@ class RequestException extends Exception
     /**
      * The response that resulted in an error
      *
-     * @var Requests_Response
+     * @var Response
      */
     public $response;
 

--- a/src/Exception/API/RequestException.php
+++ b/src/Exception/API/RequestException.php
@@ -91,12 +91,14 @@ class RequestException extends Exception
     /**
      * Factory a new StackPath API exception.
      *
+     * @param string $pluginVersion
      * @param string $requestUrl
      * @param array $requestOptions
      * @param Response $response
      * @return RequestException
      */
     public static function create(
+        $pluginVersion,
         $requestUrl,
         array $requestOptions,
         Response $response
@@ -125,12 +127,19 @@ class RequestException extends Exception
             && WP_DEBUG
             && WP_DEBUG_LOG
         ) {
-            error_log('An error was received from the StackPath API');
-            error_log("Request URL: {$requestUrl}");
-            error_log('Request options:');
-            error_log(Message::debugFormat($requestOptions));
-            error_log('Response:');
-            error_log(Message::debugFormat($response));
+            error_log("[StackPath WordPress Plugin {$pluginVersion}] An error was received from the StackPath API");
+            error_log("[StackPath WordPress Plugin {$pluginVersion}] Request URL: {$requestUrl}");
+
+            if ($response->requestId !== null) {
+                error_log("[StackPath WordPress Plugin {$pluginVersion}] Request ID: {$response->requestId}");
+            }
+
+            error_log(
+                "[StackPath WordPress Plugin {$pluginVersion}] Request options: "
+                . Message::debugFormat($requestOptions)
+            );
+
+            error_log("[StackPath WordPress Plugin {$pluginVersion}] Response: " . Message::debugFormat($response));
         }
 
         // Pull the error messages out of the response body

--- a/src/WordPress/Message.php
+++ b/src/WordPress/Message.php
@@ -70,11 +70,14 @@ class Message
         // API request exceptions have more information to show to users.
         if ($e instanceof RequestException) {
             $description = $e->detailedErrorMessage();
-            $debugInformation = [
-                'Request URL' => $e->requestUrl,
-                'Request options' => $e->requestOptions,
-                'Response' => $e->response,
-            ];
+            $debugInformation = ['Request URL' => $e->requestUrl];
+
+            if ($e->response->requestId !== null) {
+                $debugInformation['Request ID'] = $e->response->requestId;
+            }
+
+            $debugInformation['Request options'] = $e->requestOptions;
+            $debugInformation['Response'] = $e->response;
         }
 
         return new self($title, $description, $debugInformation);

--- a/src/WordPress/Message.php
+++ b/src/WordPress/Message.php
@@ -27,15 +27,32 @@ class Message
     public $description;
 
     /**
+     * A set of key => any-type pairs of debug information
+     *
+     * This is typically used to show low level details when the plugin
+     * encounters an error from the StackPath API.
+     *
+     * If WP_DEBUG and WP_DEBUG_DISPLAY are true, and the error message didn't
+     * come from an AJAX action, then debug information is shown to the user in
+     * the UI. If WP_DEBUG and WB_DEBUG_LOG are both true then debug information
+     * is sent to the PHP error_log.
+     *
+     * @var array
+     */
+    public $debugInformation = [];
+
+    /**
      * Build a new user message
      *
      * @param string $title
      * @param string|null $description
+     * @param array $debugInformation
      */
-    public function __construct($title, $description = null)
+    public function __construct($title, $description = null, array $debugInformation = [])
     {
         $this->title = $title;
         $this->description = $description;
+        $this->debugInformation = $debugInformation;
     }
 
     /**
@@ -47,8 +64,34 @@ class Message
      */
     public static function fromException($title, Exception $e)
     {
-        $description = $e instanceof RequestException ? $e->detailedErrorMessage() : $e->getMessage();
-        return new self($title, $description);
+        $description = $e->getMessage();
+        $debugInformation = [];
+
+        // API request exceptions have more information to show to users.
+        if ($e instanceof RequestException) {
+            $description = $e->detailedErrorMessage();
+            $debugInformation = [
+                'Request URL' => $e->requestUrl,
+                'Request options' => $e->requestOptions,
+                'Response' => $e->response,
+            ];
+        }
+
+        return new self($title, $description, $debugInformation);
+    }
+
+    /**
+     * Format debug information for display or logging
+     *
+     * Debug information is in PHP's print_r() format with blank lines removed
+     * and two space indentation for easier readability.
+     *
+     * @param mixed $input
+     * @return string
+     */
+    public static function debugFormat($input)
+    {
+        return preg_replace('/^\h*\v+/m', '', preg_replace('/ {2}/', ' ', print_r($input, true)));
     }
 
     /**
@@ -79,5 +122,15 @@ class Message
     public function hasDescription()
     {
         return $this->description !== null;
+    }
+
+    /**
+     * Determine if the message has debug information
+     *
+     * @return bool
+     */
+    public function hasDebugInformation()
+    {
+        return count($this->debugInformation) > 0;
     }
 }

--- a/src/WordPress/Plugin.php
+++ b/src/WordPress/Plugin.php
@@ -288,8 +288,7 @@ class Plugin
      */
     public function log(Message $message)
     {
-        $now = new DateTime();
-        $logEntry = "[{$now->format(DateTime::ATOM)}][StackPath WordPress Plugin {$this->version()}] {$message->title}";
+        $logEntry = "[StackPath WordPress Plugin {$this->version()}] {$message->title}";
 
         if ($message->hasDescription()) {
             $logEntry .= " - {$message->description}";

--- a/src/WordPress/Plugin.php
+++ b/src/WordPress/Plugin.php
@@ -78,6 +78,8 @@ class Plugin
         $this->settings = $settings;
         $this->apiClient = $apiClient;
         $this->wordPress = $wordPress;
+
+        $this->apiClient->setPluginVersion($this->version());
     }
 
     /**

--- a/src/WordPress/Plugin/PostActions.php
+++ b/src/WordPress/Plugin/PostActions.php
@@ -41,7 +41,12 @@ trait PostActions
             // Note authentication errors
             $transientData->addError(new Message(
                 'Unable to authenticate with the StackPath API',
-                'Please check your client ID and secret and try again.'
+                'Please check your client ID and secret and try again.',
+                [
+                    'Request URL' => $e->requestUrl,
+                    'Request options' => $e->requestOptions,
+                    'Response' => $e->response,
+                ]
             ));
 
             $this->redirectTo('stackpath-log-in', $transientData);

--- a/src/WordPress/Plugin/PostActions.php
+++ b/src/WordPress/Plugin/PostActions.php
@@ -43,6 +43,7 @@ trait PostActions
                 'Please check your client ID and secret and try again.',
                 [
                     'Request URL' => $e->requestUrl,
+                    'Request ID' => $e->response->requestId,
                     'Request options' => $e->requestOptions,
                     'Response' => $e->response,
                 ]

--- a/src/WordPress/Plugin/PostActions.php
+++ b/src/WordPress/Plugin/PostActions.php
@@ -13,6 +13,7 @@ use StackPath\WordPress\TransientData;
 
 /**
  * @property \StackPath\WordPress\Settings $settings
+ * @property \StackPath\API\Client $apiClient
  * @property \StackPath\WordPress\Integration\WordPressInterface $wordPress
  */
 trait PostActions
@@ -34,9 +35,7 @@ trait PostActions
             // Try to authenticate to StackPath with the client ID and secret
             $this->settings->clientId = $_POST['client_id'];
             $this->settings->clientSecret = $_POST['client_secret'];
-
-            $apiClient = new Client($this->settings, $this->wordPress);
-            $apiClient->authenticate();
+            $this->apiClient->authenticate();
         } catch (AuthenticationException $e) {
             // Note authentication errors
             $transientData->addError(new Message(

--- a/stackpath.php
+++ b/stackpath.php
@@ -23,6 +23,8 @@ if (!defined('ABSPATH')) {
     die('!');
 }
 
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
 const STACKPATH_PLUGIN_REQUIRED_PHP_VERSION = '5.6';
 
 // Perform system checks before loading the plugin.
@@ -30,9 +32,7 @@ const STACKPATH_PLUGIN_REQUIRED_PHP_VERSION = '5.6';
 // Make sure the system's PHP version is recent enough. Deactivate the plugin
 // and exit if it isn't.
 if (version_compare(PHP_VERSION, STACKPATH_PLUGIN_REQUIRED_PHP_VERSION, '<')) {
-    require_once ABSPATH . 'wp-admin/includes/plugin.php';
     deactivate_plugins(plugin_basename(__FILE__), true);
-
     wp_die(
         'The StackPath plugin requires at least PHP version '
             . STACKPATH_PLUGIN_REQUIRED_PHP_VERSION . ', but version '

--- a/templates/layout/header.php
+++ b/templates/layout/header.php
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
                 <p>Check out this plugin on <a href="https://www.github.com/stackpath/stackpath-wordpress/">GitHub</a> if you'd like to give feedback or see how it works.</p>
                 <?php if (WP_DEBUG) : ?>
                     <p><strong>Debug information</strong></p>
-                    <p>You are seeing this because both <code>WP_DEBUG</code> is set to <code>true</code> in <code>wp-config.php</code>.</p>
+                    <p>You are seeing this because <code>WP_DEBUG</code> is set to <code>true</code> in <code>wp-config.php</code>.</p>
                     <div class="stackpath-dashboard-panel" style="padding: 1em; margin: 0 0 12px;">
                         <?php global $wp_version, $wpdb; ?>
 

--- a/templates/partials/message.php
+++ b/templates/partials/message.php
@@ -4,6 +4,8 @@ if (!defined('ABSPATH')) {
     die('!');
 }
 
+use StackPath\WordPress\Message;
+
 /** @var \StackPath\WordPress\Message $message */
 /** @var string $messageType */
 ?>
@@ -13,5 +15,23 @@ if (!defined('ABSPATH')) {
 
     <?php if ($message->hasDescription()) : ?>
         <p><?= nl2br($message->description) ?></p>
+    <?php endif; ?>
+
+    <?php if (
+        $message->hasDebugInformation()
+        && defined('WP_DEBUG')
+        && defined('WP_DEBUG_DISPLAY')
+        && WP_DEBUG
+        && WP_DEBUG_DISPLAY
+    ) : ?>
+        <p><strong>Debug Information</strong></p>
+        <p>You are seeing this because both <code>WP_DEBUG</code> and <code>WP_DEBUG_DISPLAY</code> are set to <code>true</code> in <code>wp-config.php</code>.</p>
+
+        <div class="stackpath-message-debug-information">
+            <?php foreach ($message->debugInformation as $key => $value) : ?>
+                <strong><?= $key ?></strong>
+                <pre class="stackpath-message-debug-information-value"><?= htmlentities(Message::debugFormat($value)) ?></pre>
+            <?php endforeach; ?>
+        </div>
     <?php endif; ?>
 </div>


### PR DESCRIPTION
Fixes #1 .

Changes proposed in this pull request:
* Add debug information to error messages. Display or log low level StackPath API call details depending on WordPress' `WP_DEBUG`, `WP_DEBUG_DISPLAY`, and `WP_DEBUG_LOG` settings.
* Separate StackPath API request IDs from API error responses for easier reporting to StackPath support
* Handle more kinds of error details than strings, namely arrays and `stackpath.rpc.BadRequest` error objects
* Remove an extra timestamp from `error_log()` messages
* Use a more standards compliant user-agent string in StackPath API requests
* Fix a grammatical error in the "More" dropdown's debug information
* Remove an unnecessary object instantiation when authenticating to the StackPath API