### PR TITLE
Remove unused site properties

### DIFF
--- a/src/Site.php
+++ b/src/Site.php
@@ -57,24 +57,6 @@ class Site
     public $features = [];
 
     /**
-     * URLs used as API login URLs for sites with the WAF feature
-     *
-     * The StackPath WAF processes these URLs differently than standard browser
-     * requests.
-     *
-     * @var string[]
-     */
-    public $apiLoginUrls = [];
-
-    /**
-     * The StackPath POPs that route all incoming requests
-     *
-     * Shield POP Codes
-     * @var string[]
-     */
-    public $shieldPopCodes = [];
-
-    /**
      * The date a site was created
      *
      * @var DateTime
@@ -109,11 +91,6 @@ class Site
     public $monitoring;
 
     /**
-     * @var stdClass[]
-     */
-    public $scopes = [];
-
-    /**
      * Build a site object
      *
      * @param string $id
@@ -122,8 +99,6 @@ class Site
      * @param string|null $status
      * @param string[] $features
      * @param string[] $apiUrls
-     * @param string[] $apiLoginUrls
-     * @param string[] $shieldPopCodes
      * @param bool $monitoring
      * @param DateTime|null $createdAt
      * @param DateTime|null $updatedAt
@@ -135,8 +110,6 @@ class Site
         $status = null,
         array $features = [],
         array $apiUrls = [],
-        array $apiLoginUrls = [],
-        array $shieldPopCodes = [],
         $monitoring = false,
         DateTime $createdAt = null,
         DateTime $updatedAt = null
@@ -146,8 +119,6 @@ class Site
         $this->label = $label;
         $this->status = $status;
         $this->features = $features;
-        $this->apiLoginUrls = $apiLoginUrls;
-        $this->shieldPopCodes = $shieldPopCodes;
         $this->createdAt = $createdAt;
         $this->updatedAt = $updatedAt;
         $this->apiUrls = $apiUrls;
@@ -170,8 +141,6 @@ class Site
             $site->status,
             $site->features,
             $site->apiUrls,
-            $site->apiLoginUrls,
-            $site->shieldPopCodes,
             $site->monitoring,
             DateTime::createFromFormat(Plugin::DATETIME_FORMAT, $site->createdAt, new DateTimeZone('UTC')),
             DateTime::createFromFormat(Plugin::DATETIME_FORMAT, $site->updatedAt, new DateTimeZone('UTC'))

--- a/stackpath.php
+++ b/stackpath.php
@@ -4,7 +4,7 @@
  * Plugin Name: StackPath
  * Description: Place your WordPress site behind the StackPath edge network for easy CDN, firewall, and monitoring control
  * Plugin URI: https://github.com/stackpath/stackpath-wordpress
- * Version: 0.1.0
+ * Version: 0.2.1
  * Author: StackPath, LLC
  * Author URI: https://www.stackpath.com/
  * License: GPL2


### PR DESCRIPTION
Addresses #3.

Changes proposed in this pull request:
* Remove the unused `scopes`, `shieldPopCodes`, and `apiLoginUrls` site properties. `scopes` wasn't in use by the plugin, and the others have been dropped upstream by StackPath. Removing the other two prevent a fatal error when trying to build a `StackPath\Site` object from an API response.