### PR TITLE
Adjust wordpress cookies

### DIFF
--- a/src/Site.php
+++ b/src/Site.php
@@ -391,7 +391,7 @@ class Site
                         'bypassCache' => [
                             [
                                 'enabled' => true,
-                                'cookieFilter' => 'wp-*,wordpress,comment_*,woocommerce_*',
+                                'cookieFilter' => 'wp-*,wordpress_*,comment_*,woocommerce_*',
                             ],
                         ],
                     ],
@@ -420,7 +420,7 @@ class Site
                         'bypassCache' => [
                             [
                                 'enabled' => false,
-                                'cookieFilter' => 'wp-*,wordpress,comment_*,woocommerce_*',
+                                'cookieFilter' => 'wp-*,wordpress_*,comment_*,woocommerce_*',
                             ],
                         ],
                     ],

--- a/templates/cache.php
+++ b/templates/cache.php
@@ -82,7 +82,7 @@ if ($transientData->getFormData('bypass_cache') !== null) {
 <div class="stackpath-dashboard-panel">
     <div>Proxy all requests to your origin server when the following cookies exist in the request:</div>
 
-    <p><code>wp-*, wordpress, comment_*, woocommerce_*</code></p>
+    <p><code>wp-*, wordpress_*, comment_*, woocommerce_*</code></p>
 
     <div>This ensures all dynamic content comes from the origin instead of the cache.</div>
 


### PR DESCRIPTION
Fixes #8.

Changes proposed in this pull request:
* Update the list of "bypass cache if present" cookies to replace `wordpress` with `wordpress_*` (9766262)
* Update the configuration page wording to reflect the above (69b17af)

This does **not** address a situation where `LOGGED_IN_COOKIE` is customized in `wp-config.php`, and so an additional fix could be to use the value of that constant, rather than the default strings. I wanted my fix to be narrow in scope for now, so I didn't attempt to address that case.