### PR TITLE
Account for stackpath submenu not being set

### DIFF
--- a/src/WordPress/Plugin.php
+++ b/src/WordPress/Plugin.php
@@ -186,9 +186,12 @@ class Plugin
 
             // Here be dragons.
             //
-            // Remove the duplicate "StackPath" item from the sub-menu.
+            // Remove the duplicate "StackPath" item from the sub-menu, only if it exists. It may
+            // not due to, e.g. a permissions-management plugin.
             global $submenu;
-            array_shift($submenu['stackpath']);
+            if (isset($submenu) && isset($submenu['stackpath']) && is_array($submenu['stackpath'])) {
+                array_shift($submenu['stackpath']);
+            }
         });
 
         // Register actions


### PR DESCRIPTION
If `$submenu['stackpath']` is not set at all, the `array_shift()` call causes a fatal error in PHP 8+. In PHP versions prior to 8, this situation was nonfatal.

This key could be not set due to permissions that a non-admin user might lack, and/or permissions modified by a plugin or custom code.

So, we check to be sure that the key is set and is an array before trying to `array_shift()` it.

Fixes #10.

Changes proposed in this pull request:
* Check that `$submenu['stackpath']` is set and is an array before attempting to use `array_shift()`

